### PR TITLE
Generate source maps when in dev mode

### DIFF
--- a/templates/basic/app/webpack.config.js
+++ b/templates/basic/app/webpack.config.js
@@ -132,6 +132,10 @@ module.exports = function(_, arg) {
       fs: "empty"
     }
   };
+  
+  if(arg.mode === "development"){
+    config.devtool = "source-map";
+  }
 
   if (arg.mode === "production") {
     config.plugins.push(


### PR DESCRIPTION
Generates the source maps when in development mode for debugging

<!--- Provide a general summary of your changes in the Title above -->

Changes webpack config so source maps are generated for use in chrome/vs code

## Description
Just the one config change

## Related Issue
https://github.com/Esri/arcgis-js-cli/issues/27

## Motivation and Context
Adds source maps

## How Has This Been Tested?
Tested in chrome on windows

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2278405/57743747-abaa8180-7709-11e9-8a39-04bf67e0f93a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.