### PR TITLE
Add ArcGIS API as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "npm run -s build",
     "clean": "rimraf dist",
     "test": "npm run clean && jest --coverage",
-    "build": "npm run clean && npm run flow && babel src -d dist -D --ignore '*.test.js, **/__mocks__/'",
+    "build": "npm run clean && npm run flow && babel src -d dist -D --ignore '*.test.js,**/__mocks__/'",
     "dev": "npm run clean && npm run build && jest --watch",
     "flow": "flow",
     "pretty": "prettier 'src/**/*.js' --write"

--- a/templates/app/package.json
+++ b/templates/app/package.json
@@ -5,6 +5,7 @@
     "@theintern/istanbul-loader": "^1.0.0-beta.2",
     "@types/arcgis-js-api": "~4.10.0",
     "@types/sinon": "^4.3.1",
+    "arcgis-js-api": "^4.11.1",
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "^0.28.11",


### PR DESCRIPTION
## Description
ArcGIS API was not listed as a dependency. Please note this will need to be maintained to latest version. Also fixes an error causing the app not to build on windows

## Related Issue
https://github.com/Esri/arcgis-js-cli/issues/18
https://github.com/Esri/arcgis-js-cli/issues/30

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Create app.
Clean node modules
npm install
npm start

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.