### PR TITLE
correct import path in widget viewmodel test template. standardize the test suite name

### DIFF
--- a/templates/basic/widget/tests/unit/widgets/WidgetName/WidgetNameViewModel.ts
+++ b/templates/basic/widget/tests/unit/widgets/WidgetName/WidgetNameViewModel.ts
@@ -1,9 +1,9 @@
-import <%name%>ViewModel from "../../../../../src/app/widgets/<%name%>/<%name%>ViewModel";
+import <%name%>ViewModel from "../../../../src/widgets/<%name%>/<%name%>ViewModel";
 
 const { beforeEach, suite, test } = intern.getInterface("tdd");
 const { assert } = intern.getPlugin("chai");
 
-suite("app/widgets/<%name%>/<%name%>ViewModel", () => {
+suite("widgets/<%name%>/<%name%>ViewModel", () => {
   let vm: <%name%>ViewModel;
 
   beforeEach(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
modify the Widget ViewModel template so the import path matches the directory structure.  Also changed the test suite name to follow similar pattern to default widget tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When creating a new widget using "arcgis widget" command, the generated test fails on the import.  The original code produced an import statement like:
import FooterViewModel from "../../../../../src/app/widgets/Footer/FooterViewModel";

when in fact, something like this was required:
import FooterViewModel from "../../../../src/widgets/Footer/FooterViewModel";

Also changed the template so the test suite name would match the pattern used in AppViewModel, e.g. "widgets/App/AppViewModel"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
npm test
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.