### PR TITLE
Add `view` property and constructor interface to widget template

### DIFF
--- a/templates/basic/widget/src/widgets/WidgetName.tsx
+++ b/templates/basic/widget/src/widgets/WidgetName.tsx
@@ -1,14 +1,22 @@
+import esri = __esri;
+
 import {
   aliasOf,
   declared,
   property,
   subclass
 } from "esri/core/accessorSupport/decorators";
+
 import { renderable, tsx } from "esri/widgets/support/widget";
 
 import Widget from "esri/widgets/Widget";
 
 import <%name%>ViewModel from "./<%name%>/<%name%>ViewModel";
+
+export interface <%name>Properties extends esri.WidgetProperties {
+  name?: string;
+  view?: esri.MapView | esri.SceneView;
+}
 
 const CSS = {
   base: "esri-widget <%name-lower%>-base"
@@ -16,6 +24,9 @@ const CSS = {
 
 @subclass("app.widgets.<%name%>")
 export default class <%name%> extends declared(Widget) {
+
+  @aliasOf("viewModel.view")
+  view: esri.MapView | esri.SceneView;
 
   @aliasOf("viewModel.name")
   @renderable()
@@ -26,6 +37,10 @@ export default class <%name%> extends declared(Widget) {
   })
   @renderable()
   viewModel: <%name%>ViewModel = new <%name%>ViewModel();
+
+  constructor(properties?: <%name>Properties) {
+    super();
+  }
 
   render() {
     return (

--- a/templates/basic/widget/src/widgets/WidgetName/WidgetNameViewModel.ts
+++ b/templates/basic/widget/src/widgets/WidgetName/WidgetNameViewModel.ts
@@ -1,14 +1,29 @@
+import esri = __esri;
+
 import Accessor from "esri/core/Accessor";
 
-import { declared, property, subclass } from "esri/core/accessorSupport/decorators";
+import {
+  declared,
+  property,
+  subclass
+} from "esri/core/accessorSupport/decorators";
+
+import { whenDefinedOnce } from "esri/core/watchUtils";
 
 @subclass("app.widgets.<%name%>.<%name%>ViewModel")
 export default class <%name%>ViewModel extends declared(Accessor) {
+
+  @property() view: esri.MapView | esri.SceneView;
 
   @property() name = "Slagathor";
 
   constructor(params?: any) {
     super();
+    whenDefinedOnce(this, "view", this.init.bind(this));
+  }
+  
+  init(view: esri.MapView | esri.SceneView) {
+    console.log(view.scale);
   }
 
 }


### PR DESCRIPTION
## Description
Add `view` property and constructor interface to widget template.

## Related Issue
https://github.com/Esri/arcgis-js-cli/issues/52

## Motivation and Context
Problem: Every time I scaffold a widget I have to add a constructor interface and view property. I assume that's common for most users (?).

Fix: Add those items to the template.

## How Has This Been Tested?
No. Does not effect the CLI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.