### PR TITLE
Closes #73 - enable CommonJS module syntax in file-loader and url-loader

### DIFF
--- a/templates/vue/app/webpack.config.js
+++ b/templates/vue/app/webpack.config.js
@@ -74,7 +74,8 @@ module.exports = function(_, arg) {
                     loader: 'url-loader',
                     options: {
                         // Inline files smaller than 10 kB (10240 bytes)
-                        limit: 10 * 1024
+                        limit: 10 * 1024,
+                        esModule: false
                     }
                 },
                 {
@@ -83,7 +84,8 @@ module.exports = function(_, arg) {
                         {
                             loader: 'file-loader',
                             options: {
-                                name: 'build/[name].[ext]'
+                                name: 'build/[name].[ext]',
+                                esModule: false
                             }
                         }
                     ]

--- a/templates/vue/app/webpack.tests.config.js
+++ b/templates/vue/app/webpack.tests.config.js
@@ -46,7 +46,8 @@ module.exports = {
                 loader: 'url-loader',
                 options: {
                     // Inline files smaller than 10 kB (10240 bytes)
-                    limit: 10 * 1024
+                    limit: 10 * 1024,
+                    esModule: false
                 }
             },
             {
@@ -55,7 +56,8 @@ module.exports = {
                     {
                         loader: 'file-loader',
                         options: {
-                            name: 'build/[name].[ext]'
+                            name: 'build/[name].[ext]',
+                            esModule: false
                         }
                     }
                 ]


### PR DESCRIPTION
## Description
set `esModule: false` for fonts and images in `webpack config(s)` 

## Related Issue
https://github.com/Esri/arcgis-js-cli/issues/73

## Motivation and Context
Required to render default Vue template correctly

## How Has This Been Tested?
1. `npm run start` renders fonts correctly in browser
2. `npm run serve` renders fonts correctly in browser
3. `npm run build` generates index.html file with correct urls in <style> tag

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.