### PR TITLE
fix(styles): fix styles subcommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "useTabs": true
   },
   "dependencies": {
-    "arcgis-js-api": "^4.20.2",
+    "@esri/calcite-components": "1.0.0-beta.69",
+    "arcgis-js-api": "4.22.2",
     "browser-sync": "^2.27.5",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
@@ -119,7 +120,6 @@
     "cpy": "^8.1.2",
     "cross-spawn-promise": "^0.10.2",
     "del": "^6.0.0",
-    "fibers": "^5.0.0",
     "fs-extra": "^10.0.0",
     "inquirer": "^8.1.5",
     "lodash.camelcase": "^4.3.0",

--- a/src/commands/styles/preview.ts
+++ b/src/commands/styles/preview.ts
@@ -1,9 +1,7 @@
 import { promises as fs } from 'fs';
 import { create, Options } from 'browser-sync';
 import sass from 'sass';
-import fiber from 'fibers';
 import chokidar from 'chokidar';
-import pify from 'pify';
 import { listThemes } from './list';
 import { Arguments, Argv } from 'yargs';
 import { debug, error, info, log } from '../../lib/messaging';
@@ -16,7 +14,6 @@ interface PreviewArgs {
 }
 
 const bs = create();
-const sassRender = pify(sass.render);
 
 // yargs exports
 export const command = 'preview [theme]';
@@ -42,11 +39,13 @@ export async function compileTheme(
 	themeName: string,
 	destinationDir = buildPath('<cwd>/<workspace>', dirs),
 ): Promise<void> {
-	const contents = await sassRender({
-		file: buildPath(`<cwd>/${themeName}/main.scss`, dirs),
-		fiber,
-		outputStyle: 'compressed',
-		includePaths: [buildPath(`<cwd>/${themeName}/<base>`, dirs), buildPath('<cwd>/<workspace>/<base>', dirs)],
+	const contents = await sass.compile(buildPath(`<cwd>/${themeName}/main.scss`, dirs), {
+		style: 'compressed',
+		loadPaths: [
+			buildPath(`<cwd>/${themeName}/<base>`, dirs),
+			buildPath('<cwd>/<workspace>/<base>', dirs),
+			buildPath('<nodeModules>', dirs)
+		],
 	});
 
 	await ensureDir(destinationDir);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This fixes the `styles` command to work with the latest, namely:

- drops use of `fibers` as it is [obsolete and no longer recommended](https://github.com/laverdet/node-fibers#readme)
- ensures the `@esri/calcite-components` dependency is available during create and preview

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/Esri/arcgis-js-cli/issues/106

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The latest dependencies broke the `styles` subcommand.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran `create` and `preview` successfully.

## Screenshots (if appropriate): N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.