### PR TITLE
Fix various errors

### DIFF
--- a/src/commands/styles.ts
+++ b/src/commands/styles.ts
@@ -3,7 +3,7 @@ import { Argv } from 'yargs';
 // yargs exports
 export const command = 'styles <subcommand>';
 export const describe = 'Run subcommands to work with a custom CSS theme';
-export const builder = (yargs: Argv) => {
+export const builder = (yargs: Argv): unknown => {
 	/* eslint-disable @typescript-eslint/no-var-requires */
 	return yargs
 		.command(require('./styles/create'))
@@ -18,4 +18,4 @@ export const builder = (yargs: Argv) => {
 export const handler = noop;
 
 // internals
-function noop() {}
+function noop(): void {}

--- a/src/commands/styles/scaffold.ts
+++ b/src/commands/styles/scaffold.ts
@@ -57,7 +57,7 @@ export async function scaffold(workspacePath: string, force = false): Promise<vo
 
 	debug(`copying preview file`);
 
-	await cpy('preview/', buildPath(`${workspacePath}/<preview>`, dirs), {
+	await cpy('preview', buildPath(`${workspacePath}/<preview>`, dirs), {
 		cwd: buildPath(`<dirname>/../../`, dirs),
 	});
 

--- a/src/lib/cleanDirectories.ts
+++ b/src/lib/cleanDirectories.ts
@@ -22,8 +22,9 @@ const cleanDirectories = async (target: string, dest: string, tests: string, typ
 			rimraf(`${target}/tests/unit/widgets/WidgetName/`, async () => {
 				await del([`${target}/src/widgets/WidgetName.tsx`]);
 				rimraf(`${target}/src/widgets/WidgetName/`, async () => {
-					await copy(`${target}/src/`, dest + '/');
-					await copy(`${target}/tests/`, tests + '/');
+					console.log('clean ', `${target}`);
+					// await copy(`${target}/src/`, dest + '/');
+					// await copy(`${target}/tests/`, tests + '/');
 					rimraf(`${target}/**`, resolve);
 				});
 			});

--- a/src/lib/cleanDirectories.ts
+++ b/src/lib/cleanDirectories.ts
@@ -22,9 +22,6 @@ const cleanDirectories = async (target: string, dest: string, tests: string, typ
 			rimraf(`${target}/tests/unit/widgets/WidgetName/`, async () => {
 				await del([`${target}/src/widgets/WidgetName.tsx`]);
 				rimraf(`${target}/src/widgets/WidgetName/`, async () => {
-					console.log('clean ', `${target}`);
-					// await copy(`${target}/src/`, dest + '/');
-					// await copy(`${target}/tests/`, tests + '/');
 					rimraf(`${target}/**`, resolve);
 				});
 			});

--- a/src/lib/createWidget.ts
+++ b/src/lib/createWidget.ts
@@ -13,13 +13,13 @@
 
 import path from 'path';
 import fs from 'fs';
-import fse from 'fs-extra';
+import cpy from 'cpy';
 import chalk from 'chalk';
 import pkgDir from 'pkg-dir';
 import camelCase from 'lodash.camelcase';
 import startCase from 'lodash.startcase';
 
-import { compose, map, replace, toLower } from 'ramda';
+import { compose, replace } from 'ramda';
 
 import cleanDirectories from './cleanDirectories';
 import copyUpdateFiles from './copyUpdateFiles';
@@ -37,7 +37,7 @@ const createWidget = async ({ argv }: any) => {
 	try {
 		const data: any = await fs.promises.readFile(path.resolve(process.cwd(), 'package.json'));
 		pkg = JSON.parse(data);
-		console.log(pkg);
+
 		if (!pkg || (pkg && pkg.arcgis.type !== 'jsapi' && pkg.arcgis.type !== 'exb')) {
 			console.info(
 				chalk.red.bold(
@@ -63,13 +63,13 @@ const createWidget = async ({ argv }: any) => {
 
 	try {
 		const rootDir = await pkgDir(__dirname);
-		await fse.copy(`${rootDir}/${directory}`, target, {
-			filter: (s) => !s.includes('DS_Store'),
+		await cpy(`${rootDir}/${directory}`, target, {
+			filter: (s) => !s.path.includes('DS_Store'),
 		});
 		await copyUpdateFiles(readDirR(target), name);
 		await cleanDirectories(target, dest, tests, argv.type);
 	} catch (error) {
-		console.info(chalk.red.bold(`Widget creation failed: ${error.message}\n`));
+		console.error(chalk.red.bold(`Widget creation failed: ${error.message}\n`));
 		return Promise.reject(new Error(`Widget creation failed: ${error.message}`));
 	}
 };


### PR DESCRIPTION
* Fixed small linter errors in styles.ts 
* Removes trailing slash from preview copy in scaffold.ts
* Removes copy commands from cleanDirectories.ts 

Tested locally - creating themes and new widgets seems to be working again.

Related: https://github.com/Esri/arcgis-js-cli/issues/105, https://github.com/Esri/arcgis-js-cli/issues/106 