### PR TITLE
SDK rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,13 +9,13 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ## Getting Involved
 
-Third-party patches are absolutely essential on our quest to create the best maps app with the ArcGIS API for JavaScript.
+Third-party patches are absolutely essential on our quest to create the best maps app with the ArcGIS Maps SDK for JavaScript.
 However, they're not the only way to get involved with the development of `@arcgis/cli`.
 You can help the project tremendously by discovering and [reporting bugs](#reporting-bugs),
 [improving documentation](#improving-documentation),
 helping others with [GitHub issues](https://github.com/Esri/arcgis-js-cli/issues),
 tweeting to [@ArcGISJSAPI](https://twitter.com/ArcGISJSAPI),
-and spreading the word about mapps-app-javascript and the [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/) among your colleagues and friends.
+and spreading the word about mapps-app-javascript and the [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/) among your colleagues and friends.
 
 ## Reporting Bugs
 
@@ -25,7 +25,7 @@ Second, search through the reported issues for your issue,
 and if it's already reported, just add any additional details in the comments.
 
 Also, please only report issues related to the `@arcgis/cli`.
-If your issue is related to the ArcGIS API for JavaScript, please contact [Esri Tech Support](https://support.esri.com/contact-tech-support) or ask the Esri community on [GeoNet](https://geonet.esri.com/community/developers/web-developers/arcgis-api-for-javascript).
+If your issue is related to the ArcGIS Maps SDK for JavaScript, please contact [Esri Tech Support](https://support.esri.com/contact-tech-support) or ask the Esri community on [GeoNet](https://geonet.esri.com/community/developers/web-developers/arcgis-api-for-javascript).
 
 After you made sure that you've found a new `@arcgis/cli` bug,
 please use the provided issue template when creating your issue.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [travis-img]: https://img.shields.io/travis/Esri/arcgis-js-cli/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/Esri/arcgis-js-cli
 
-This CLI will allow you to quickly scaffold various applications for the [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/).
+This CLI will allow you to quickly scaffold various applications for the [ArcGIS Maps SDK JavaScript](https://developers.arcgis.com/javascript/).
 
 > NOTE: It is highly recommended that you use [Vite](https://vitejs.dev/) directly to build your apps. We also provide a number of [application samples](https://github.com/Esri/jsapi-resources/tree/master/esm-samples) that you can use. The 4.25 release of this CLI will most likely be the last release. There are other tools already suited for using existing repositories for applications, such as [degit](https://github.com/Rich-Harris/degit).
 
@@ -159,7 +159,7 @@ Positionals:
 Options:
       --version            Show version number                             [boolean]
       -e, --with-examples  when specified, the created theme will include examples
-                           from the API                                    [boolean]
+                           from the SDK                                    [boolean]
       -b, --with-base      when specified, the created theme will include base files
                            for local overrides (advanced)                  [boolean]
       -f, --force          overwrites a theme if it already exists         [boolean]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@arcgis/cli",
 	"version": "4.25.1",
-	"description": "CLI to scaffold ArcGIS API for JavaScript applications",
+	"description": "CLI to scaffold ArcGIS Maps SDK for JavaScript applications",
 	"main": "dist/index.js",
 	"bin": {
 		"arcgis": "dist/index.js"

--- a/src/commands/styles/create.ts
+++ b/src/commands/styles/create.ts
@@ -23,7 +23,7 @@ export const builder = (yargs: Argv) => {
 		})
 		.option('with-examples', {
 			alias: 'e',
-			describe: 'when specified, the created theme will include examples from the API',
+			describe: 'when specified, the created theme will include examples from the SDK',
 			type: 'boolean',
 		})
 		.option('with-base', {

--- a/templates/vite/app/README.md
+++ b/templates/vite/app/README.md
@@ -6,15 +6,15 @@ This application is written in [TypeScript](http://www.typescriptlang.org/) and 
 
 You can develop, test, and build the application using various commands.
 
-You will need to create an [SDK Key](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/#api-keys) using a free [ArcGIS Developer Account](https://developers.arcgis.com/sign-up/).
+You will need to create an [API Key](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/#api-keys) using a free [ArcGIS Developer Account](https://developers.arcgis.com/sign-up/).
 
-Add your SDK Key to a `.env` file at the root of this project.
+Add your API Key to a `.env` file at the root of this project.
 
 ```
 VITE_API_KEY=MY-DEVELOPER-API-KEY
 ```
 
-Vite will pick up the SDK Key for use in your application.
+Vite will pick up the API Key for use in your application.
 
 Run the application in development mode with a local development server.
 ```sh

--- a/templates/vite/app/README.md
+++ b/templates/vite/app/README.md
@@ -1,4 +1,4 @@
-# ArcGIS API for JavaScript Template Application
+# ArcGIS Maps SDK for JavaScript Template Application
 
 ## Usage
 
@@ -6,15 +6,15 @@ This application is written in [TypeScript](http://www.typescriptlang.org/) and 
 
 You can develop, test, and build the application using various commands.
 
-You will need to create an [API Key](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/#api-keys) using a free [ArcGIS Developer Account](https://developers.arcgis.com/sign-up/).
+You will need to create an [SDK Key](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/#api-keys) using a free [ArcGIS Developer Account](https://developers.arcgis.com/sign-up/).
 
-Add your API Key to a `.env` file at the root of this project.
+Add your SDK Key to a `.env` file at the root of this project.
 
 ```
 VITE_API_KEY=MY-DEVELOPER-API-KEY
 ```
 
-Vite will pick up the API Key for use in your application.
+Vite will pick up the SDK Key for use in your application.
 
 Run the application in development mode with a local development server.
 ```sh

--- a/templates/vite/app/src/style.css
+++ b/templates/vite/app/src/style.css
@@ -1,5 +1,5 @@
 /*************************************************
-  Custom ArcGIS JavaScript API theming.
+  Custom ArcGIS Maps SDK for JavaScript theming.
 *************************************************/
 @import url("https://js.arcgis.com/4.25/esri/themes/light/main.css");
 


### PR DESCRIPTION
This PR replaces all instances of the old naming convention with the new name. It roughly follows a convention of using the full name once per section followed by just using shorthand "SDK". The plan is to merge this change on or before Dec 14.

For more information see the [Introducing the ArcGIS Map SDKs](https://www.esri.com/arcgis-blog/products/developers/announcements/introducing-the-arcgis-maps-sdks/) blog post. 

Items of note:
* This PR does not create a new version of the CLI.