### PR TITLE
Update style.css

### DIFF
--- a/templates/vite/app/src/style.css
+++ b/templates/vite/app/src/style.css
@@ -9,6 +9,18 @@
   Add application and widget styles.
 *************************************************/
 
+html {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  -webkit-box-sizing: inherit;
+  -moz-box-sizing: inherit;
+  box-sizing: inherit;
+  }
+
+
 html,
 body {
   padding: 0;
@@ -33,8 +45,8 @@ body {
   flex-flow: row;
   justify-content: space-between;
   align-items: center;
-  height: 40px;
   width: 100%;
+  padding: 12px 15px;
   background-color: var(--main-bg-color);
   color: var(--font-color-white);
 }
@@ -42,7 +54,6 @@ body {
 .app--header-title {
   font-size: 20px;
   font-weight: 500;
-  margin-left: 0.5rem;
 }
 
 @media screen and (min-width: 880px) {
@@ -57,6 +68,6 @@ body {
 }
 
 .app--view {
+  flex: 1;
   width: 100%;
-  height: calc(100% - 40px);
 }


### PR DESCRIPTION
Minor CSS changes make the default app more consistent with esri design guidelines and fixes overflow and other design issues in mobile screen sizes

- added the css box sizing fix, which fixes the overflow on the search bar on 
- removed hardcoded header size, to better accomodate various app titles, maintain consistent spacing with the search bar 
- added padding using standard esri spacing intervals (15px)

<!--- Provide a general summary of your changes in the Title above -->

## Description
- added the css box sizing fix, which fixes the overflow on the search bar on 
- removed hardcoded header size, to better accomodate various app titles, maintain consistent spacing with the search bar 
- added padding using standard esri spacing intervals (15px)

## Related Issue
#123 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Generated CSS is not responsive, overflows at smaller screen sizes, does not maintain consistent spacing.

## How Has This Been Tested?
it's a css change, there is not much to test.

## Screenshots (if appropriate):
### Before
![image](https://github.com/Esri/arcgis-js-cli/assets/43123950/f9d4af6a-5140-42b2-a397-55fccfe832f4)

### After
![image](https://github.com/Esri/arcgis-js-cli/assets/43123950/41f67fea-7c57-4703-a3ca-d16fcbc953f2)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsurexabout any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.